### PR TITLE
Prefer existing templates on explicit render calls

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,23 @@
+name: RSpec Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: CI
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+
+      - name: Run bundle install
+        working-directory: ${{env.api-dir}}
+        run: |
+          gem install bundler
+          bundle install --jobs 4 --retry 3
+
+      - name: Build and test with rspec
+        run: bundle exec rake spec

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -11,4 +11,4 @@ jobs:
       with:
         ruby-version: '3.0' # Not needed with a .ruby-version file
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - run: bundle exec rake
+    - run: bundle exec rake spec

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: CI
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -3,21 +3,12 @@ name: RSpec Tests
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
     name: CI
-    runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-
-      - name: Run bundle install
-        working-directory: ${{env.api-dir}}
-        run: |
-          gem install bundler
-          bundle install --jobs 4 --retry 3
-
-      - name: Build and test with rspec
-        run: bundle exec rake spec
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.0' # Not needed with a .ruby-version file
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - run: bundle exec rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    implicit_rendering (0.1.2)
+    implicit_rendering (0.1.3)
       actionpack
       activesupport
       zeitwerk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    implicit_rendering (0.1.3)
+    implicit_rendering (0.1.4)
       actionpack
       activesupport
       zeitwerk

--- a/lib/CHANGELOG.md
+++ b/lib/CHANGELOG.md
@@ -1,3 +1,7 @@
+## ImplicitRendering 0.1.4
+
+* Fix bug for existing templates in combination with explicit `render` call
+
 ## ImplicitRendering 0.1.3
 
 * Fix bug for existing templates

--- a/lib/implicit_rendering.rb
+++ b/lib/implicit_rendering.rb
@@ -17,22 +17,25 @@ module ImplicitRendering
   end
 
   def default_render
-    template_name = self.class.implicit_render_mapping&.dig(action_name)
+    override_template_name = self.class.implicit_render_mapping&.dig(action_name)
 
-    return super unless perform_implicit_rendering?(template_name)
+    return super unless perform_implicit_rendering?(action_name, override_template_name)
 
-    render template_name
+    render override_template_name
   end
 
   def render(options={})
-    if options.is_a?(Hash) && (template_name = self.class.implicit_render_mapping&.dig(options[:action].to_s))
+    if options.is_a?(Hash) &&
+      (override_template_name = self.class.implicit_render_mapping&.dig(options[:action].to_s)) &&
+      perform_implicit_rendering?(options[:action], override_template_name)
+
       @action_before_implicit_render = options[:action]
-      options[:action] = template_name
+      options[:action] = override_template_name
     end
     super
   end
 
-  def perform_implicit_rendering?(template_name)
+  def perform_implicit_rendering?(action_name, template_name)
     return false if template_exists?(action_name.to_s, _prefixes, variants: request.variant)
 
     template_name.present? &&

--- a/lib/implicit_rendering/version.rb
+++ b/lib/implicit_rendering/version.rb
@@ -1,3 +1,3 @@
 module ImplicitRendering
-  VERSION = '0.1.3'.freeze
+  VERSION = '0.1.4'.freeze
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe PostsController do
+
+  render_views
+
+  context 'POST #create' do
+    it 'prefers existing templates' do
+      post :create
+      expect(controller.action_before_implicit_render).to eq nil
+      expect(response.body).to include 'Hello from posts/new!'
+    end
+  end
+
+end

--- a/spec/internal/app/controllers/posts_controller.rb
+++ b/spec/internal/app/controllers/posts_controller.rb
@@ -1,0 +1,12 @@
+class PostsController < ActionController::Base
+
+  prepend ::ImplicitRendering
+  implicit_rendering(
+    new: '_form'
+  )
+
+  def create
+    render action: :new
+  end
+
+end

--- a/spec/internal/app/views/posts/new.html.erb
+++ b/spec/internal/app/views/posts/new.html.erb
@@ -1,0 +1,1 @@
+Hello from posts/new!

--- a/spec/internal/config/routes.rb
+++ b/spec/internal/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   resources :users do
     get :something, on: :member
   end
+  resources :posts, only: :create
 end


### PR DESCRIPTION
This PR fixes the following issue:

**Situation**
- A controller has a default mapping defined
- A template for the action already exists
- An explicit call to `render`

**Issue**
Previously, we would have tried to look for the template from the implicit rendering mapping

**Correct**
Still prefer the existing template
